### PR TITLE
Add ability to shuffle playlist on click

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# PLAYTRON
+# Playtron
 
 A web app to make it easier to manage your Spotify playlists. First release in progress.
 
 ## Installation instructions
-npm install
-npm run dev
+- npm install
+- npm run dev

--- a/README.md
+++ b/README.md
@@ -1,47 +1,7 @@
-# Astro Starter Kit: Minimal
+# PLAYTRON
 
-```sh
-npm create astro@latest -- --template minimal
-```
+A web app to make it easier to manage your Spotify playlists. First release in progress.
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/minimal)
-[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/astro/tree/latest/examples/minimal)
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/withastro/astro?devcontainer_path=.devcontainer/minimal/devcontainer.json)
-
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
-
-## 🚀 Project Structure
-
-Inside of your Astro project, you'll see the following folders and files:
-
-```text
-/
-├── public/
-├── src/
-│   └── pages/
-│       └── index.astro
-└── package.json
-```
-
-Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
-
-There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
-
-Any static assets, like images, can be placed in the `public/` directory.
-
-## 🧞 Commands
-
-All commands are run from the root of the project, from a terminal:
-
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `npm install`             | Installs dependencies                            |
-| `npm run dev`             | Starts local dev server at `localhost:4321`      |
-| `npm run build`           | Build your production site to `./dist/`          |
-| `npm run preview`         | Preview your build locally, before deploying     |
-| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro -- --help` | Get help using the Astro CLI                     |
-
-## 👀 Want to learn more?
-
-Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).
+## Installation instructions
+npm install
+npm run dev

--- a/src/components/playlist-area.astro
+++ b/src/components/playlist-area.astro
@@ -12,7 +12,7 @@ const {data} = Astro.props;
 <style>
     .root {
         display: grid;
-        grid-template-columns: repeat(auto-fit, 100px );
+        grid-template-columns: repeat(auto-fit, 100px);
         gap: 43px;
         align-items: center;
         justify-items: center;

--- a/src/components/playlist-area.astro
+++ b/src/components/playlist-area.astro
@@ -26,7 +26,8 @@ const {data} = Astro.props;
             <PlaylistTile
                 name= {pl.name}
                 tracks={pl.tracks.total}
-                imageSrc={pl.images[0].url} />
+                imageSrc={pl.images[0].url}
+                plId={pl.id} />
         ))
     }
 </div>

--- a/src/components/playlist-tile.astro
+++ b/src/components/playlist-tile.astro
@@ -28,13 +28,22 @@ const { name, tracks, imageSrc, plId } = Astro.props;
 <script>
     const tiles = document.querySelectorAll("div.playlist-tile");
 
+    async function makePutRequest(plId: any) {
+        const resp = await fetch("/playlists/" + plId, {
+            method: "PUT",
+            body: JSON.stringify({action: "shuffle"})
+        });
+        console.log(resp.status);
+    }
+
     tiles.forEach((elem) => {
         const tile = elem as HTMLDivElement;
         const plId = tile.dataset.plId
-        tile.addEventListener('click', () => {
-            alert(`Clicked on playlist with id ${plId}`);
+        tile.addEventListener('click', async () => {
+            await makePutRequest(plId);
         });
     });
+
 </script>
 
 <div class="root card playlist-tile" data-pl-id={plId}>

--- a/src/components/playlist-tile.astro
+++ b/src/components/playlist-tile.astro
@@ -32,7 +32,7 @@ const { name, tracks, imageSrc, plId } = Astro.props;
             method: "PUT",
             body: JSON.stringify({action: "shuffle"})
         });
-        return resp.ok
+        return resp.ok;
     }
 
     tiles.forEach((elem) => {

--- a/src/components/playlist-tile.astro
+++ b/src/components/playlist-tile.astro
@@ -7,6 +7,7 @@ interface Props {
 }
 
 const { name, tracks, imageSrc } = Astro.props;
+// CHRISTIAN START HERE: clicking a tile should go to a new endpoint that implements the hard shuffle
 ---
 <style>
     .root {

--- a/src/components/playlist-tile.astro
+++ b/src/components/playlist-tile.astro
@@ -7,7 +7,7 @@ interface Props {
 }
 
 const { name, tracks, imageSrc } = Astro.props;
-// CHRISTIAN START HERE: clicking a tile should go to a new endpoint that implements the hard shuffle
+// CHRISTIAN START HERE: clicking a tile should send a put to /playlists/<id>
 ---
 <style>
     .root {
@@ -24,7 +24,17 @@ const { name, tracks, imageSrc } = Astro.props;
     }
 </style>
 
-<div class="root card">
+<script>
+    const tiles = document.querySelectorAll("div.playlist-tile");
+
+    tiles.forEach((tile) => {
+        tile.addEventListener('click', () => {
+            alert("tile was clicked");
+        });
+    });
+</script>
+
+<div class="root card playlist-tile">
     <Image
         src={imageSrc}
         alt=`Cover of playlist "${name}"`

--- a/src/components/playlist-tile.astro
+++ b/src/components/playlist-tile.astro
@@ -8,7 +8,6 @@ interface Props {
 }
 
 const { name, tracks, imageSrc, plId } = Astro.props;
-// CHRISTIAN START HERE: clicking a tile should send a put to /playlists/<id>
 ---
 <style>
     .root {
@@ -33,20 +32,25 @@ const { name, tracks, imageSrc, plId } = Astro.props;
             method: "PUT",
             body: JSON.stringify({action: "shuffle"})
         });
-        console.log(resp.status);
+        return resp.ok
     }
 
     tiles.forEach((elem) => {
         const tile = elem as HTMLDivElement;
-        const plId = tile.dataset.plId
+        const plId = tile.dataset.plId;
+        const name = tile.dataset.name;
         tile.addEventListener('click', async () => {
-            await makePutRequest(plId);
+            const success = await makePutRequest(plId);
+            const alertMsg = success ?
+                `Playlist ${name} shuffled successfully` :
+                `Error while shuffling playlist ${name}`;
+            alert(alertMsg);
         });
     });
 
 </script>
 
-<div class="root card playlist-tile" data-pl-id={plId}>
+<div class="root card playlist-tile" data-pl-id={plId} data-name={name}>
     <Image
         src={imageSrc}
         alt=`Cover of playlist "${name}"`

--- a/src/components/playlist-tile.astro
+++ b/src/components/playlist-tile.astro
@@ -4,9 +4,10 @@ interface Props {
     name: string;
     tracks: number;
     imageSrc: string;
+    plId: string;
 }
 
-const { name, tracks, imageSrc } = Astro.props;
+const { name, tracks, imageSrc, plId } = Astro.props;
 // CHRISTIAN START HERE: clicking a tile should send a put to /playlists/<id>
 ---
 <style>
@@ -27,14 +28,16 @@ const { name, tracks, imageSrc } = Astro.props;
 <script>
     const tiles = document.querySelectorAll("div.playlist-tile");
 
-    tiles.forEach((tile) => {
+    tiles.forEach((elem) => {
+        const tile = elem as HTMLDivElement;
+        const plId = tile.dataset.plId
         tile.addEventListener('click', () => {
-            alert("tile was clicked");
+            alert(`Clicked on playlist with id ${plId}`);
         });
     });
 </script>
 
-<div class="root card playlist-tile">
+<div class="root card playlist-tile" data-pl-id={plId}>
     <Image
         src={imageSrc}
         alt=`Cover of playlist "${name}"`

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
 export const SP_API_URL = "https://api.spotify.com/v1"
 export const SP_ACC_URL = "https://accounts.spotify.com"
 
-// CHRISTIAN TODO: move file to script
+// TODO: move file to script

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,4 @@
 export const SP_API_URL = "https://api.spotify.com/v1"
 export const SP_ACC_URL = "https://accounts.spotify.com"
+
+// CHRISTIAN TODO: move file to script

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="astro/client" />
 
 /* CHRISTIAN TODO: implement cookie checking via middleware, and set session on locals
+Then you can delete duplicated token validation logic and possibly refresh
 declare namespace App {
     interface Locals {
         error: Error;

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,11 +1,1 @@
 /// <reference types="astro/client" />
-
-/* CHRISTIAN TODO: implement cookie checking via middleware, and set session on locals
-Then you can delete duplicated token validation logic and possibly refresh
-declare namespace App {
-    interface Locals {
-        error: Error;
-        errorObj: any;
-    }
-}
-*/

--- a/src/pages/auth.astro
+++ b/src/pages/auth.astro
@@ -8,7 +8,7 @@ const params = new URLSearchParams(
         redirect_uri: "http://localhost:4321/callback",
         show_dialog: "true",
         scope: "playlist-modify-public playlist-modify-private"
-        // CHRISTIAN TODO: provide state arg
+        // TODO: provide state arg
     }
 );
 

--- a/src/pages/auth.astro
+++ b/src/pages/auth.astro
@@ -6,8 +6,9 @@ const params = new URLSearchParams(
         client_id: import.meta.env.PT_ID,
         response_type: "code",
         redirect_uri: "http://localhost:4321/callback",
-        show_dialog: "true"
-        //scope: "playlist-read-private" CHRISTIAN TODO: provide proper scopes and state
+        show_dialog: "true",
+        scope: "playlist-modify-public playlist-modify-private"
+        // CHRISTIAN TODO: provide state arg
     }
 );
 

--- a/src/pages/callback.ts
+++ b/src/pages/callback.ts
@@ -1,4 +1,4 @@
-import type { APIContext } from 'astro';
+import type { APIRoute } from 'astro';
 import { SP_ACC_URL } from '../constants';
 
 function makeTokenRequest(code: string): Promise<Response> {
@@ -23,23 +23,25 @@ function makeTokenRequest(code: string): Promise<Response> {
     // CHRISTIAN TODO: implement refreshing token
 }
 
-export async function GET(context: APIContext) {
-    const qparams = context.url.searchParams;
+export const GET: APIRoute = async ({redirect, cookies, url}) => {
+    const qparams = url.searchParams;
     if (qparams.has("error")) {
-        return context.redirect("/error");
-    } else if (qparams.has("code")) {
+        return redirect("/error");
+    } else if (!qparams.has("code")) {
+        return redirect("/error");
+    } else {
         const response = await makeTokenRequest(qparams.get("code")!)
 
         if (response.status !== 200) {
             console.log(await response.text());
-            return context.redirect("/error");
+            return redirect("/error");
         }
 
         const data = await response.json()
-        context.cookies.set("session", data.access_token, {
+        cookies.set("session", data.access_token, {
             httpOnly: true,
             maxAge: 5*60
         });
-        return context.redirect("/");
+        return redirect("/");
     }
 }

--- a/src/pages/callback.ts
+++ b/src/pages/callback.ts
@@ -20,7 +20,6 @@ function makeTokenRequest(code: string): Promise<Response> {
     console.log(authOptions);
     console.log(url);
     return fetch(url, authOptions);
-    // CHRISTIAN TODO: implement refreshing token
 }
 
 export const GET: APIRoute = async ({redirect, cookies, url}) => {

--- a/src/pages/callback.ts
+++ b/src/pages/callback.ts
@@ -40,7 +40,7 @@ export const GET: APIRoute = async ({redirect, cookies, url}) => {
         const data = await response.json()
         cookies.set("session", data.access_token, {
             httpOnly: true,
-            maxAge: 5*60
+            maxAge: 60*60
         });
         return redirect("/");
     }

--- a/src/pages/home.astro
+++ b/src/pages/home.astro
@@ -37,7 +37,6 @@ if(!spotify.validateMePlaylistsResponse(plData)) {
 const displayName = uData.display_name;
 const avatarSrc = uData.images[0]?.url || defaultAvatar;
 const numPlaylists = plData.total;
-console.log(`CHRISTIAN: first aid id:${plData.items[0].id} snapshot:${plData.items[0].snapshot_id}`);
 ---
 <style is:global>
 :root{

--- a/src/pages/home.astro
+++ b/src/pages/home.astro
@@ -14,13 +14,16 @@ if (token === undefined) {
 
 const spotify = new SpotifyAPIHelper(token);
 
-const resps = await Promise.all([
-    spotify.makeCurrentUserPlaylistRequest(),
-    spotify.makeCurrentUserRequest()
-]).catch(err => {
-    console.log(err);
+let resps;
+try {
+    resps = await Promise.all([
+        spotify.makeCurrentUserPlaylistRequest(),
+        spotify.makeCurrentUserRequest()
+    ]);
+} catch(error) {
+    console.log(error);
     return;
-});
+}
 if (!resps) {
     return Astro.redirect("/error");
 }

--- a/src/pages/home.astro
+++ b/src/pages/home.astro
@@ -34,6 +34,7 @@ if(!spotify.validateMePlaylistsResponse(plData)) {
 const displayName = uData.display_name;
 const avatarSrc = uData.images[0]?.url || defaultAvatar;
 const numPlaylists = plData.total;
+console.log(`CHRISTIAN: first aid id:${plData.items[0].id} snapshot:${plData.items[0].snapshot_id}`);
 ---
 <style is:global>
 :root{

--- a/src/pages/home.astro
+++ b/src/pages/home.astro
@@ -40,7 +40,8 @@ const numPlaylists = plData.total;
     --primary: 142 71% 45%;
     --background: 20 14% 4%;
     --foreground: 0 0% 95%;
-    --card: 24 9% 10%
+    --card: 24 9% 10%;
+    font-family: sans-serif;
 }
 .card {
     background-color: hsl(var(--card));

--- a/src/pages/home.astro
+++ b/src/pages/home.astro
@@ -6,7 +6,6 @@ import defaultAvatar from '../images/avatar_example.png';
 import PlaylistArea from "../components/playlist-area.astro";
 import {SpotifyAPIHelper} from "../script/spotify_api";
 
-// CHRISTIAN TODO: implement a connect to spotify button on home
 const token = Astro.cookies.get("session")?.value;
 if (token === undefined) {
     return Astro.redirect("/auth");
@@ -115,7 +114,6 @@ body {
 	</head>
 	<body>
         <!--Header -->
-        <!-- CHRISTIAN TODO: make this appear for all pages -->
         <div class="bg-card">
             <a href="/">
             <Image class="wordmark" src={wordmark} alt="Playtron"/>

--- a/src/pages/playlists/[pl_id].ts
+++ b/src/pages/playlists/[pl_id].ts
@@ -32,7 +32,7 @@ REORDER ALGORITHM
 const MAX_REQS = 20;
 async function performHardShuffle(plId: string, token: string): Promise<any> {
     // CHRISTIAN TODO: call playlist request to determine length and get snapshot
-    const plsLeng = MAX_REQS;
+    const plsLeng = 5;
     const snapshot = "#####";
     if (plsLeng < 2) {
         return;

--- a/src/pages/playlists/[pl_id].ts
+++ b/src/pages/playlists/[pl_id].ts
@@ -34,12 +34,22 @@ async function performHardShuffle(plId: string, plLeng: number, snapshot: string
     }
 
     const window = Math.ceil(plLeng/MAX_REQS);
-    const paste = 0;
-    const currSnap = snapshot;
+    let paste = 0;
+    let currSnap = snapshot;
     for (let i=0; i<MAX_REQS; ++i) {
+        const lastPossibleStartIndex = plLeng - window;
+        if (lastPossibleStartIndex < paste) {
+            // there's fewer tracks left to shuffle than a full window
+            break;
+        }
 
+        // pick a random int uniformly from [paste, lastPossibleStartIndex]
+        const startIndex =
+            Math.floor(Math.random() * (lastPossibleStartIndex - paste + 1)) + paste
 
+        // make request
 
+        paste += window;
     }
 }
 

--- a/src/pages/playlists/[pl_id].ts
+++ b/src/pages/playlists/[pl_id].ts
@@ -11,9 +11,37 @@ SCHEMA
         - For sort: {field: string}
 
 - if there's no snapshot, then just fail
-- get action
-- get
+- get action - for now if it's not "shuffle", just error
+
+REORDER ALGORITHM
+- let MAX_REQS be the max number of requests we want to make to reorder one playlist
+- let window be the bigger between 1 and the len(playlist) divided by MAX_REQS
+- let paste_location be 0
+- let snapshot_id be the snapshot we started with
+- while paste_location is more than a window away from the end of the playlist:
+   - select a random int in
+     [paste_location + 1, <the last location where you can grab a full window>]
+   - send request where range_start is that int, insert_before is paste_location,
+     range_length is window, snapshot_id is snapshot_id
+   - if the request failed, error out
+   - otherwise, update snapshot_id, advance paste_location by window
  */
+
+const MAX_REQS = 20;
+async function performHardShuffle(plId: string, plLeng: number, snapshot: string): Promise<any> {
+    if (plLeng < 2) {
+        return;
+    }
+
+    const window = Math.ceil(plLeng/MAX_REQS);
+    const paste = 0;
+    const currSnap = snapshot;
+    for (let i=0; i<MAX_REQS; ++i) {
+
+
+
+    }
+}
 
 export const PUT: APIRoute = ({params, request, url}) => {
     if (!url.searchParams.has("snapshot")) {

--- a/src/pages/playlists/[pl_id].ts
+++ b/src/pages/playlists/[pl_id].ts
@@ -3,7 +3,7 @@ import { SpotifyAPIHelper } from "../../script/spotify_api";
 
 /*
 SCHEMA
-- playtron/playlists/<id>?snapshot=<>
+- playtron/playlists/<id>
   - GET: 
   - PUT:
      - action: "shuffle"|"sort"
@@ -33,7 +33,7 @@ const MAX_REQS = 20;
 async function performHardShuffle(plId: string, token: string): Promise<any> {
     // CHRISTIAN TODO: call playlist request to determine length and get snapshot
     const plsLeng = MAX_REQS;
-    const snapshot = "CHRISTIAN";
+    const snapshot = "#####";
     if (plsLeng < 2) {
         return;
     }
@@ -81,17 +81,18 @@ export const PUT: APIRoute = async ({params, request, url, cookies, redirect}) =
         return redirect("/auth");
     }
 
-    if (!url.searchParams.has("snapshot")) {
-        return makeErrorResponse("Missing snapshot", 400);
-    }
-
-    const reqData = await request.json();
-    if (!reqData.action || reqData.action != "shuffle") {
-        return makeErrorResponse("Missing action", 400);
+    let reqData;
+    try {
+        reqData = await request.json();
+        if (!reqData.action || reqData.action != "shuffle") {
+            throw new Error();
+        }
+    } catch(error) {
+        return makeErrorResponse("Bad request body", 400);
     }
 
     try {
-        performHardShuffle(params.pl_id!, token);
+        await performHardShuffle(params.pl_id!, token);
     } catch (error) {
         console.log(error);
         return makeErrorResponse("Error shuffling playlist", 500);

--- a/src/pages/playlists/[pl_id].ts
+++ b/src/pages/playlists/[pl_id].ts
@@ -1,0 +1,28 @@
+import type { APIRoute } from "astro";
+
+/*
+SCHEMA
+- playtron/playlists/<id>?snapshot=<>
+  - GET: 
+  - PUT:
+     - action: "shuffle"|"sort"
+     - params: JSON
+        - For shuffle, nothing for now
+        - For sort: {field: string}
+
+- if there's no snapshot, then just fail
+- get action
+- get
+ */
+
+export const PUT: APIRoute = ({params, request, url}) => {
+    if (!url.searchParams.has("snapshot")) {
+        const bodyData = {
+            errorMessage: "Missing snapshot"
+        };
+        return new Response(JSON.stringify(bodyData), {
+            status: 400
+        });
+    }
+    return new Response();
+};

--- a/src/script/spotify_api.ts
+++ b/src/script/spotify_api.ts
@@ -1,7 +1,7 @@
 
 import { SP_API_URL } from "../constants";
 
-export type PlaylistData = {
+export interface PlaylistData {
     name: string,
     tracks: {
         href: string,
@@ -12,11 +12,11 @@ export type PlaylistData = {
             url: string
         }
     ]
-};
+}
 
-export type MePlaylistsResponse = {
-    total: number,
-    items: PlaylistData[]
+export interface MePlaylistsResponse {
+    total: number;
+    items: PlaylistData[];
 }
 
 function getJsonResponseData(response: Response) {
@@ -42,6 +42,18 @@ export class SpotifyAPIHelper {
             }
         }).then(getJsonResponseData);
     }
+    
+    private makePostRequest(endpoint: string, body: string) {
+        const url = SP_API_URL + endpoint;
+        return fetch(url, {
+            headers: {
+                Authorization: `Bearer ${this.token}`,
+                "Content-Type": "application/json"
+            },
+            method: "POST",
+            body
+        }).then(getJsonResponseData);
+    }
 
     makeCurrentUserRequest() {
         return this.makeGetRequest("/me");
@@ -51,10 +63,14 @@ export class SpotifyAPIHelper {
         return this.makeGetRequest("/me/playlists");
     }
 
-    makeUpdatePlaylistItemsRequest() {
-        // CHRISTIAN: Implement
-        const plId = "CHRISTIAN";
-        const url = SP_API_URL + `/playlists/${plId}/tracks`;
+    makeUpdatePlaylistItemsRequest(playlistId: string, rangeStart: number, insertBefore: number, rangeLength: number, snapshotId: string) {
+        const body = JSON.stringify({
+            range_start: rangeStart,
+            insert_before: insertBefore,
+            range_length: rangeLength,
+            snapshot_id: snapshotId
+        });
+        return this.makePostRequest(`/playlists/${playlistId}/tracks`, body);
     }
 
     validatePlaylistData(obj: any): obj is PlaylistData {

--- a/src/script/spotify_api.ts
+++ b/src/script/spotify_api.ts
@@ -6,6 +6,7 @@ import { SP_API_URL } from "../constants";
 // from what we get back from the API and from what we know in the code
 export interface PlaylistData {
     name: string,
+    id: string,
     tracks: {
         href: string,
         total: number

--- a/src/script/spotify_api.ts
+++ b/src/script/spotify_api.ts
@@ -1,6 +1,8 @@
 
 import { SP_API_URL } from "../constants";
 
+// CHRISTIAN TODO: refactor this module to handle validation and error responses and failures
+// and more consistently use async/await over promises
 export interface PlaylistData {
     name: string,
     tracks: {
@@ -34,25 +36,27 @@ export class SpotifyAPIHelper {
         this.token = token;
     }
 
-    private makeGetRequest(endpoint: string) {
+    private async makeGetRequest(endpoint: string) {
         const url = SP_API_URL + endpoint;
-        return fetch(url, {
+        const resp = await fetch(url, {
             headers: {
                 Authorization: `Bearer ${this.token}`
             }
-        }).then(getJsonResponseData);
+        });
+        return getJsonResponseData(resp);
     }
     
-    private makePostRequest(endpoint: string, body: string) {
+    private async makePostRequest(endpoint: string, body: string) {
         const url = SP_API_URL + endpoint;
-        return fetch(url, {
+        const resp = await fetch(url, {
             headers: {
                 Authorization: `Bearer ${this.token}`,
                 "Content-Type": "application/json"
             },
             method: "POST",
             body
-        }).then(getJsonResponseData);
+        });
+        return getJsonResponseData(resp);
     }
 
     makeCurrentUserRequest() {

--- a/src/script/spotify_api.ts
+++ b/src/script/spotify_api.ts
@@ -51,6 +51,12 @@ export class SpotifyAPIHelper {
         return this.makeGetRequest("/me/playlists");
     }
 
+    makeUpdatePlaylistItemsRequest() {
+        // CHRISTIAN: Implement
+        const plId = "CHRISTIAN";
+        const url = SP_API_URL + `/playlists/${plId}/tracks`;
+    }
+
     validatePlaylistData(obj: any): obj is PlaylistData {
         const nameC = typeof obj.name === "string";
         const tracksC = obj.tracks &&

--- a/src/script/spotify_api.ts
+++ b/src/script/spotify_api.ts
@@ -1,7 +1,7 @@
 
 import { SP_API_URL } from "../constants";
 
-// CHRISTIAN TODO: refactor this module to handle validation and error responses and failures
+// TODO: refactor this module to handle validation and error responses and failures
 // and more consistently use async/await over promises. Also print helpful stuff in console log
 // from what we get back from the API and from what we know in the code
 export interface PlaylistData {
@@ -37,7 +37,7 @@ export class SpotifyAPIHelper {
         this.token = token;
     }
 
-    // CHRISTIAN TODO: deprecate this and make everyone use handleRequest
+    // TODO: deprecate this and make everyone use handleRequest
     private async makeGetRequest(endpoint: string) {
         const url = SP_API_URL + endpoint;
         console.log("GET request to " + url);

--- a/src/script/spotify_api.ts
+++ b/src/script/spotify_api.ts
@@ -2,7 +2,8 @@
 import { SP_API_URL } from "../constants";
 
 // CHRISTIAN TODO: refactor this module to handle validation and error responses and failures
-// and more consistently use async/await over promises
+// and more consistently use async/await over promises. Also print helpful stuff in console log
+// from what we get back from the API and from what we know in the code
 export interface PlaylistData {
     name: string,
     tracks: {
@@ -46,14 +47,15 @@ export class SpotifyAPIHelper {
         return getJsonResponseData(resp);
     }
     
-    private async makePostRequest(endpoint: string, body: string) {
+    private async makePutRequest(endpoint: string, body: string) {
         const url = SP_API_URL + endpoint;
+        console.error("CHRISTIAN: body is " + body);
         const resp = await fetch(url, {
             headers: {
                 Authorization: `Bearer ${this.token}`,
                 "Content-Type": "application/json"
             },
-            method: "POST",
+            method: "PUT",
             body
         });
         return getJsonResponseData(resp);
@@ -74,7 +76,7 @@ export class SpotifyAPIHelper {
             range_length: rangeLength,
             snapshot_id: snapshotId
         });
-        return this.makePostRequest(`/playlists/${playlistId}/tracks`, body);
+        return this.makePutRequest(`/playlists/${playlistId}/tracks`, body);
     }
 
     validatePlaylistData(obj: any): obj is PlaylistData {


### PR DESCRIPTION
# Add ability to shuffle playlist on click

This PR adds the ability to shuffle a playlist when you click it. This is accomplished by splitting the playlist up into chunks and rearranging those chunks randomly within the playlist. The Spotify API only provides the ability to move one chunk of songs within one request, so for now, a maximum of 20 [update playlist requests](https://developer.spotify.com/documentation/web-api/reference/reorder-or-replace-playlists-tracks) are sent for a given playlist. This is to limit API load and avoid corrupting a playlist.